### PR TITLE
fix: add message type to BaseMessage type

### DIFF
--- a/lib/__definition.d.ts
+++ b/lib/__definition.d.ts
@@ -171,6 +171,7 @@ declare interface BaseListQueryParams {
 }
 
 export declare class BaseMessage extends MessagePrototype {
+  message: string;
   messageId: number;
   parentMessageId: number;
   parentMessage: BaseMessage | null;
@@ -183,10 +184,15 @@ export declare class BaseMessage extends MessagePrototype {
   scheduledInfo: ScheduledInfo | null;
   suggestedReplies: string[] | null;
   isIdentical(message: BaseMessage): boolean;
-  applyThreadInfoUpdateEvent(threadInfoUpdateEvent: ThreadInfoUpdateEvent): boolean;
+  applyThreadInfoUpdateEvent(
+    threadInfoUpdateEvent: ThreadInfoUpdateEvent
+  ): boolean;
   applyReactionEvent(reactionEvent: ReactionEvent): void;
   applyParentMessage(parentMessage: BaseMessage): boolean;
-  submitForm(data: { formId: string; answers: Record<string, string> }): Promise<void>;
+  submitForm(data: {
+    formId: string;
+    answers: Record<string, string>;
+  }): Promise<void>;
 }
 
 declare abstract class BaseMessageCollection<


### PR DESCRIPTION
![image](https://github.com/sendbird/sendbird-chat-sdk-javascript/assets/52112750/160006f3-7045-41f7-b5f1-c227b153c37e)

Property 'message' does not exist on type 'BaseMessage'. Did you mean 'messageId'?ts(2551)
__definition.d.ts(174, 3): 'messageId' is declared here.

log of `channel.lastMessage` 

![image](https://github.com/sendbird/sendbird-chat-sdk-javascript/assets/52112750/7e5af41f-a230-46bf-8059-6a732d5aabcf)
